### PR TITLE
feat: add exclude/include buttons

### DIFF
--- a/src/components/Playist/playlist.module.css
+++ b/src/components/Playist/playlist.module.css
@@ -70,6 +70,42 @@
     color: #a3a3a3;
 }
 
+.audio__toggle {
+    appearance: none;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    background: none;
+    cursor: pointer;
+}
+
+.audio__toggle > svg {
+    width: 100%;
+    height: 100%;
+    stroke: #1db954;
+}
+
+.audio__toggle__included:hover, .audio__toggle__excluded {
+    transform: rotate(45deg);
+}
+
+.audio__toggle__included:hover > svg, .audio__toggle__excluded > svg {
+    stroke: #ba4943;
+}
+
+.audio__toggle__excluded:hover {
+    transform: rotate(0deg);
+}
+
+.audio__toggle__excluded:hover > svg {
+    stroke: #1db954;
+}
+
+.audio__excluded .audio__wrapper {
+    opacity: .5;
+    text-decoration: line-through;
+}
+
 .background {
     position: absolute;
     overflow: hidden;


### PR DESCRIPTION
This feature adds an ability for user to which tracks to exclude from playlist creation or which tracks to include. By default all tracks generated are flagged for inclusion.

![image](https://github.com/baris5d/gptuneify/assets/4410500/0cbbb295-8d9b-4940-97f6-387c0b5a5c6d)
